### PR TITLE
fix: set module max stack count to 16

### DIFF
--- a/src/main/java/io/sc3/plethora/gameplay/registry/Registration.java
+++ b/src/main/java/io/sc3/plethora/gameplay/registry/Registration.java
@@ -182,7 +182,7 @@ public final class Registration {
     }
 
     private static <T extends Item> T registerModule(String id, Function<Item.Settings, T> itemCtor) {
-      return register("module_" + id, itemCtor.apply(properties().maxCount(1)));
+      return register("module_" + id, itemCtor.apply(properties().maxCount(16)));
     }
   }
 


### PR DESCRIPTION
<img width="305" alt="image" src="https://user-images.githubusercontent.com/24967425/212522936-22d26c61-3e9e-40fb-88ee-80e5e0e9e816.png">
Sets the module max stack count to 16. I thought that 16 would fit in better compared to 64. I have done many tests and have not noticed any missing items, though there still might be bugs.
This makes bound introspection modules stackable as well (if hey are bound to the same person), this might need to be discussed/fixed