### PR TITLE
fix: remove typo in changed module message

### DIFF
--- a/src/main/java/io/sc3/plethora/gameplay/neural/NeuralHelpers.java
+++ b/src/main/java/io/sc3/plethora/gameplay/neural/NeuralHelpers.java
@@ -128,7 +128,7 @@ public class NeuralHelpers {
             @Override
             public IModuleContainer safeGet() throws LuaException {
                 if (moduleHash != computer.getModuleHash()) {
-                    throw new LuaException("A moudle has changed");
+                    throw new LuaException("A module has changed");
                 }
 
                 return container;


### PR DESCRIPTION
This resolves #26 by changing "moudle" to "module".

<img width="547" alt="image" src="https://user-images.githubusercontent.com/24967425/216234434-c542e7f0-a9c9-4d77-a69c-4462f7808272.png">
Were you just planning to fix the typo or reconsider the message/make it more descriptive?