### PR TITLE
 fix: entity motion inconsistencies

### DIFF
--- a/src/main/java/io/sc3/plethora/integration/vanilla/meta/entity/EntityMeta.java
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/meta/entity/EntityMeta.java
@@ -1,5 +1,6 @@
 package io.sc3.plethora.integration.vanilla.meta.entity;
 
+import io.sc3.plethora.util.VelocityDeterminable;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
@@ -56,7 +57,7 @@ public class EntityMeta extends BaseMetaProvider<Entity> {
         result.put("name", EntityHelpers.getName(entity));
         result.put("displayName", entity.getName().getString());
 
-        Vec3d motion = entity.getVelocity();
+        Vec3d motion = ((VelocityDeterminable)entity).getMotion();
         result.put("motionX", motion.x);
         result.put("motionY", motion.y);
         result.put("motionZ", motion.z);

--- a/src/main/java/io/sc3/plethora/mixin/EntityMixin.java
+++ b/src/main/java/io/sc3/plethora/mixin/EntityMixin.java
@@ -1,0 +1,26 @@
+package io.sc3.plethora.mixin;
+
+import io.sc3.plethora.util.VelocityDeterminable;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.Vec3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(Entity.class)
+public class EntityMixin implements VelocityDeterminable {
+    @Unique
+    public Vec3d prevPos = Vec3d.ZERO;
+    public Vec3d motion = Vec3d.ZERO;
+
+    @Override
+    public void storePrevPos() {
+        Vec3d pos = ((Entity)((Object)this)).getPos();
+        motion = pos.subtract(prevPos);
+        prevPos = pos;
+    }
+
+    @Override
+    public Vec3d getMotion() {
+        return motion;
+    }
+}

--- a/src/main/java/io/sc3/plethora/mixin/EntityMixin.java
+++ b/src/main/java/io/sc3/plethora/mixin/EntityMixin.java
@@ -2,26 +2,40 @@ package io.sc3.plethora.mixin;
 
 import io.sc3.plethora.util.VelocityDeterminable;
 import net.minecraft.entity.Entity;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(Entity.class)
 public class EntityMixin implements VelocityDeterminable {
-    @Unique
-    private Vec3d prevPos = Vec3d.ZERO;
-    @Unique
-    private Vec3d motion = Vec3d.ZERO;
+  @Unique
+  private Vec3d prevPos = Vec3d.ZERO;
+  @Unique
+  private Vec3d motion = Vec3d.ZERO;
+  @Unique
+  private RegistryKey<World> prevWorld;
 
-    @Override
-    public void storePrevPos() {
-        Vec3d pos = ((Entity)((Object)this)).getPos();
-        motion = pos.subtract(prevPos);
-        prevPos = pos;
+  @Override
+  public void storePrevPos() {
+    var entity = (Entity) (Object) this;
+    var pos = entity.getPos();
+    var world = entity.getWorld().getRegistryKey();
+
+    // Avoid velocity spikes when changing dimensions
+    if (prevWorld != world) {
+      prevWorld = world;
+      motion = Vec3d.ZERO;
+    } else {
+      motion = pos.subtract(prevPos);
     }
 
-    @Override
-    public Vec3d getMotion() {
+    prevPos = pos;
+  }
+
+  @Override
+  public Vec3d getMotion() {
         return motion;
     }
 }

--- a/src/main/java/io/sc3/plethora/mixin/EntityMixin.java
+++ b/src/main/java/io/sc3/plethora/mixin/EntityMixin.java
@@ -9,8 +9,9 @@ import org.spongepowered.asm.mixin.Unique;
 @Mixin(Entity.class)
 public class EntityMixin implements VelocityDeterminable {
     @Unique
-    public Vec3d prevPos = Vec3d.ZERO;
-    public Vec3d motion = Vec3d.ZERO;
+    private Vec3d prevPos = Vec3d.ZERO;
+    @Unique
+    private Vec3d motion = Vec3d.ZERO;
 
     @Override
     public void storePrevPos() {

--- a/src/main/java/io/sc3/plethora/mixin/ServerWorldMixin.java
+++ b/src/main/java/io/sc3/plethora/mixin/ServerWorldMixin.java
@@ -14,4 +14,9 @@ public class ServerWorldMixin {
     private void setPrevPos(Entity entity, CallbackInfo ci) {
         ((VelocityDeterminable)entity).storePrevPos();
     }
+
+  @Inject(at = @At("TAIL"), method = "tickPassenger(Lnet/minecraft/entity/Entity;Lnet/minecraft/entity/Entity;)V")
+  private void setPrevPosRiding(Entity vehicle, Entity passenger, CallbackInfo ci) {
+    ((VelocityDeterminable)passenger).storePrevPos();
+  }
 }

--- a/src/main/java/io/sc3/plethora/mixin/ServerWorldMixin.java
+++ b/src/main/java/io/sc3/plethora/mixin/ServerWorldMixin.java
@@ -1,0 +1,17 @@
+package io.sc3.plethora.mixin;
+
+import io.sc3.plethora.util.VelocityDeterminable;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.world.ServerWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerWorld.class)
+public class ServerWorldMixin {
+    @Inject(at = @At("TAIL"), method = "tickEntity(Lnet/minecraft/entity/Entity;)V")
+    private void setPrevPos(Entity entity, CallbackInfo ci) {
+        ((VelocityDeterminable)entity).storePrevPos();
+    }
+}

--- a/src/main/java/io/sc3/plethora/util/VelocityDeterminable.java
+++ b/src/main/java/io/sc3/plethora/util/VelocityDeterminable.java
@@ -1,0 +1,8 @@
+package io.sc3.plethora.util;
+
+import net.minecraft.util.math.Vec3d;
+
+public interface VelocityDeterminable {
+    void storePrevPos();
+    Vec3d getMotion();
+}

--- a/src/main/resources/plethora.mixins.json
+++ b/src/main/resources/plethora.mixins.json
@@ -6,10 +6,12 @@
   "mixins": [
     "ClientConnectionAccessor",
     "EntityAccessor",
+    "EntityMixin",
     "LivingEntityMixin",
     "MeleeAttackGoalMixin",
     "ServerPlayerInteractionManagerAccessor",
     "ServerPlayNetworkHandlerAdapter",
+    "ServerWorldMixin",
     "SimpleInventoryAccessor",
     "TntBlockInvoker",
     "computercraft.AbstractComputerBlockEntityAccessor"


### PR DESCRIPTION
Fixes SwitchCraftCC/Plethora-Fabric#52. 

Adds a pair of mixins that calculate velocity from the entity's current position and the position in the tick prior.

Test program: 
```lua
local mods = peripheral.wrap("back")
mods.canvas().clear()
local text = mods.canvas().addText({0,0}, "")
while true do
    local meta = mods.getMetaOwner()
    text.setText(meta.motionX.." "..meta.motionY.." "..meta.motionZ)
end
```
Use on NI with introspection module, overlay glasses, and entity sensor. 
Move around, see velocity change.