### PR TITLE
feat: written/writable book meta providers

### DIFF
--- a/src/main/java/io/sc3/plethora/integration/vanilla/meta/item/WritableBookItemMeta.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/meta/item/WritableBookItemMeta.kt
@@ -1,14 +1,15 @@
 package io.sc3.plethora.integration.vanilla.meta.item
 
 import io.sc3.plethora.api.meta.ItemStackMetaProvider
-import net.minecraft.item.*
+import net.minecraft.item.ItemStack
+import net.minecraft.item.WritableBookItem
 import net.minecraft.nbt.NbtCompound
 import net.minecraft.nbt.NbtString
 
 object WritableBookItemMeta : ItemStackMetaProvider<WritableBookItem>(WritableBookItem::class.java) {
-    override fun getMeta(stack: ItemStack, item: WritableBookItem): Map<String, *> = mapOf(
-        "pages" to stack.nbt?.getList("pages", NbtCompound.STRING_TYPE.toInt())?.toArray()
-            ?.filterIsInstance<NbtString>()
-            ?.map { it.asString() }
-    )
+  override fun getMeta(stack: ItemStack, item: WritableBookItem): Map<String, *> = mapOf(
+    "pages" to stack.nbt?.getList("pages", NbtCompound.STRING_TYPE.toInt())
+      ?.filterIsInstance<NbtString>()
+      ?.map { it.asString() }
+  )
 }

--- a/src/main/java/io/sc3/plethora/integration/vanilla/meta/item/WritableBookItemMeta.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/meta/item/WritableBookItemMeta.kt
@@ -1,0 +1,14 @@
+package io.sc3.plethora.integration.vanilla.meta.item
+
+import io.sc3.plethora.api.meta.ItemStackMetaProvider
+import net.minecraft.item.*
+import net.minecraft.nbt.NbtCompound
+import net.minecraft.nbt.NbtString
+
+object WritableBookItemMeta : ItemStackMetaProvider<WritableBookItem>(WritableBookItem::class.java) {
+    override fun getMeta(stack: ItemStack, item: WritableBookItem): Map<String, *> = mapOf(
+        "pages" to stack.nbt?.getList("pages", NbtCompound.STRING_TYPE.toInt())?.toArray()
+            ?.filterIsInstance<NbtString>()
+            ?.map { it.asString() }
+    )
+}

--- a/src/main/java/io/sc3/plethora/integration/vanilla/meta/item/WrittenBookItemMeta.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/meta/item/WrittenBookItemMeta.kt
@@ -1,0 +1,19 @@
+package io.sc3.plethora.integration.vanilla.meta.item
+
+import io.sc3.plethora.api.meta.ItemStackMetaProvider
+import net.minecraft.item.ItemStack
+import net.minecraft.item.WrittenBookItem
+import net.minecraft.nbt.NbtCompound
+import net.minecraft.nbt.NbtString
+import net.minecraft.text.Text
+
+object WrittenBookItemMeta : ItemStackMetaProvider<WrittenBookItem>(WrittenBookItem::class.java) {
+    override fun getMeta(stack: ItemStack, item: WrittenBookItem): Map<String, *> = mapOf(
+        "generation" to WrittenBookItem.getGeneration(stack),
+        "author" to stack.nbt?.getString(WrittenBookItem.AUTHOR_KEY),
+        "pages" to stack.nbt?.getList(WrittenBookItem.PAGES_KEY, NbtCompound.STRING_TYPE.toInt())?.toArray()
+            ?.filterIsInstance<NbtString>()
+            ?.map { Text.Serializer.fromJson(it.asString())?.string},
+        "opened" to stack.nbt?.getBoolean(WrittenBookItem.RESOLVED_KEY)
+    )
+}

--- a/src/main/java/io/sc3/plethora/integration/vanilla/meta/item/WrittenBookItemMeta.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/meta/item/WrittenBookItemMeta.kt
@@ -8,12 +8,16 @@ import net.minecraft.nbt.NbtString
 import net.minecraft.text.Text
 
 object WrittenBookItemMeta : ItemStackMetaProvider<WrittenBookItem>(WrittenBookItem::class.java) {
-    override fun getMeta(stack: ItemStack, item: WrittenBookItem): Map<String, *> = mapOf(
-        "generation" to WrittenBookItem.getGeneration(stack),
-        "author" to stack.nbt?.getString(WrittenBookItem.AUTHOR_KEY),
-        "pages" to stack.nbt?.getList(WrittenBookItem.PAGES_KEY, NbtCompound.STRING_TYPE.toInt())?.toArray()
-            ?.filterIsInstance<NbtString>()
-            ?.map { Text.Serializer.fromJson(it.asString())?.string},
-        "opened" to stack.nbt?.getBoolean(WrittenBookItem.RESOLVED_KEY)
+  override fun getMeta(stack: ItemStack, item: WrittenBookItem): Map<String, *> {
+    val nbt = stack.nbt ?: return emptyMap<String, Any>()
+
+    return mapOf(
+      "generation" to WrittenBookItem.getGeneration(stack),
+      "author" to nbt.getString(WrittenBookItem.AUTHOR_KEY),
+      "pages" to nbt.getList(WrittenBookItem.PAGES_KEY, NbtCompound.STRING_TYPE.toInt())
+        ?.filterIsInstance<NbtString>()
+        ?.map { Text.Serializer.fromJson(it.asString())?.string },
+      "opened" to nbt.getBoolean(WrittenBookItem.RESOLVED_KEY)
     )
+  }
 }

--- a/src/main/java/io/sc3/plethora/integration/vanilla/registry/VanillaMetaRegistration.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/registry/VanillaMetaRegistration.kt
@@ -36,6 +36,8 @@ object VanillaMetaRegistration {
       provider("itemMaterial", ItemMaterialMeta)
       provider("foodItem", FoodItemMeta)
       provider("potionItem", PotionItemMeta)
+      provider("writableBookItem", WritableBookItemMeta)
+      provider("writtenBookItem", WrittenBookItemMeta)
     }
   }
 


### PR DESCRIPTION
<img width="1280" alt="image" src="https://github.com/SwitchCraftCC/Plethora-Fabric/assets/24967425/ed563080-b80b-4b67-86d5-dd01b4742392">
This adds meta providers for Book and Quills and Signed Books. `pages` is the only new property for Book and Quills, but Signed Books get `pages`, `author`, `generation`, and `opened` as well. Closes #58. Feel free to fix my code if it isn't styled correctly or could be improved. 