### PR TITLE
Force set stack during item transfers (fixes #31)

### DIFF
--- a/src/main/java/io/sc3/plethora/util/DerivedInventorySlotWrapper.kt
+++ b/src/main/java/io/sc3/plethora/util/DerivedInventorySlotWrapper.kt
@@ -1,0 +1,75 @@
+package io.sc3.plethora.util
+
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant
+import net.fabricmc.fabric.api.transfer.v1.item.base.SingleStackStorage
+import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext
+import net.fabricmc.fabric.impl.transfer.DebugMessages
+import net.fabricmc.fabric.impl.transfer.item.ItemVariantImpl
+import net.minecraft.item.ItemStack
+
+// Based on InventorySlotWrapper
+class DerivedInventorySlotWrapper(val storage: DerivedInventoryStorageImpl, val slot: Int) : SingleStackStorage() {
+  private var lastReleasedSnapshot: ItemStack? = null
+
+  override fun getStack(): ItemStack {
+    return storage.inventory.getStack(slot)
+  }
+
+  override fun setStack(stack: ItemStack) {
+    // Forced for equipment because this is used for rollbacks
+    if (storage.inventory is EquipmentInventoryWrapper) {
+      storage.inventory.forceSetStack(slot, stack)
+    } else {
+      storage.inventory.setStack(slot, stack)
+    }
+  }
+
+  override fun insert(insertedVariant: ItemVariant, maxAmount: Long, transaction: TransactionContext?): Long {
+    if (!canInsert(slot, (insertedVariant as ItemVariantImpl).cachedStack)) {
+      return 0
+    }
+    val ret = super.insert(insertedVariant, maxAmount, transaction)
+
+    return ret
+  }
+
+  private fun canInsert(slot: Int, stack: ItemStack): Boolean {
+    return storage.inventory.isValid(slot, stack)
+  }
+  override fun extract(variant: ItemVariant?, maxAmount: Long, transaction: TransactionContext?): Long {
+    return super.extract(variant, maxAmount, transaction)
+  }
+
+  override fun getCapacity(variant: ItemVariant): Int {
+    return Math.min(storage.inventory.maxCountPerStack, variant.item.maxCount)
+  }
+
+  // We override updateSnapshots to also schedule a markDirty call for the backing inventory.
+  override fun updateSnapshots(transaction: TransactionContext?) {
+    storage.markDirtyParticipant.updateSnapshots(transaction)
+    super.updateSnapshots(transaction)
+  }
+
+  override fun releaseSnapshot(snapshot: ItemStack) {
+    lastReleasedSnapshot = snapshot
+  }
+
+  override fun onFinalCommit() {
+    // Try to apply the change to the original stack
+    val original = lastReleasedSnapshot!!
+    val currentStack = stack
+    if (!original.isEmpty && original.item === currentStack.item) {
+      // None is empty and the items match: just update the amount and NBT, and reuse the original stack.
+      original.count = currentStack.count
+      original.nbt = if (currentStack.hasNbt()) currentStack.nbt!!.copy() else null
+      stack = original
+    } else {
+      // Otherwise assume everything was taken from original so empty it.
+      original.count = 0
+    }
+  }
+
+  override fun toString(): String {
+    return "InventorySlotWrapper[%s#%d]".formatted(DebugMessages.forInventory(storage.inventory), slot)
+  }
+}

--- a/src/main/java/io/sc3/plethora/util/DerivedInventoryStorageImpl.kt
+++ b/src/main/java/io/sc3/plethora/util/DerivedInventoryStorageImpl.kt
@@ -1,0 +1,79 @@
+package io.sc3.plethora.util
+
+import com.google.common.collect.MapMaker
+import net.fabricmc.fabric.api.transfer.v1.item.InventoryStorage
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant
+import net.fabricmc.fabric.api.transfer.v1.storage.base.CombinedStorage
+import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage
+import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant
+import net.fabricmc.fabric.impl.transfer.DebugMessages
+import net.minecraft.inventory.Inventory
+import net.minecraft.util.math.Direction
+import java.util.*
+
+// Based on InventoryStorageImpl
+class DerivedInventoryStorageImpl(val inventory: Inventory) :
+  CombinedStorage<ItemVariant, SingleSlotStorage<ItemVariant>>(emptyList<SingleSlotStorage<ItemVariant>>()), InventoryStorage {
+
+  /**
+   * This `backingList` is the real list of wrappers.
+   * The `parts` in the superclass is the public-facing unmodifiable sublist with exactly the right amount of slots.
+   */
+  val backingList: MutableList<DerivedInventorySlotWrapper> = mutableListOf()
+
+  /**
+   * This participant ensures that markDirty is only called once for the entire inventory.
+   */
+  val markDirtyParticipant: MarkDirtyParticipant = MarkDirtyParticipant()
+  companion object {
+    private val WRAPPERS: MutableMap<Inventory, DerivedInventoryStorageImpl> = MapMaker().weakValues().makeMap()
+    fun of(inventory: Inventory): InventoryStorage {
+      val storage: DerivedInventoryStorageImpl = WRAPPERS.computeIfAbsent(inventory) { inv: Inventory ->
+        return@computeIfAbsent DerivedInventoryStorageImpl(inv)
+      }
+      storage.resizeSlotList();
+		  return storage.getSidedWrapper(null);
+    }
+  }
+
+  override fun getSlots(): MutableList<SingleSlotStorage<ItemVariant>>? {
+    return parts
+  }
+
+  /**
+   * Resize slot list to match the current size of the inventory.
+   */
+  private fun resizeSlotList() {
+    val inventorySize = inventory.size()
+
+    // If the public-facing list must change...
+    if (inventorySize != parts.size) {
+      // Ensure we have enough wrappers in the backing list.
+      while (backingList.size < inventorySize) {
+        backingList.add(DerivedInventorySlotWrapper(this, backingList.size))
+      }
+
+      // Update the public-facing list.
+      parts = Collections.unmodifiableList<SingleSlotStorage<ItemVariant>>(backingList.subList(0, inventorySize))
+    }
+  }
+
+  private fun getSidedWrapper(direction: Direction?): InventoryStorage {
+    return this
+  }
+
+  override fun toString(): String {
+    return "InventoryStorage[" + DebugMessages.forInventory(inventory) + "]"
+  }
+  inner class MarkDirtyParticipant : SnapshotParticipant<Boolean>() {
+    override fun createSnapshot(): Boolean {
+      return java.lang.Boolean.TRUE
+    }
+
+    override fun readSnapshot(snapshot: Boolean) {}
+    override fun onFinalCommit() {
+      inventory.markDirty()
+    }
+  }
+
+}

--- a/src/main/java/io/sc3/plethora/util/EquipmentInventoryWrapper.kt
+++ b/src/main/java/io/sc3/plethora/util/EquipmentInventoryWrapper.kt
@@ -56,6 +56,11 @@ class EquipmentInventoryWrapper(
     entity.equipStack(VALUES[slot], stack)
   }
 
+  fun forceSetStack(slot: Int, stack: ItemStack) {
+    validateSlotIndex(slot)
+    entity.equipStack(VALUES[slot], stack)
+  }
+
   override fun isValid(slot: Int, stack: ItemStack): Boolean {
     validateSlotIndex(slot)
     val slotType = VALUES[slot]


### PR DESCRIPTION
`InventoryStorage` is not designed to support inventories that do not own their slots, such as `EquipmentInventoryWrapper`. An issue came up that due to the validation on `EquipmentInventoryWrapper`'s `setStack`, rollbacks during item transfers fail, causing items to be deleted (as pushItems actually does two extractions, and the first is meant to be rolled back). To solve this, I created a new `InventoryStorage`, `DerivedInventoryStorageImpl`, and an accompanying `DerivedInventorySlotWrapper` so that we can call a new function, `forceSetStack` to ensure rollbacks complete successfully. 

Note that, because of `isValid`, this does **NOT** allow setting disallowed items in equipment slots (tested this to make sure). However, we still maintain the existing behavior that `pullItems` can put more than 1 of stackable items into helmet slots (think mob skulls and carved pumpkins). Tested that `pushItems` now works, and `pullItems` remains working.