### PR TITLE
Don't allow using manipulator in adventure mode

### DIFF
--- a/src/main/java/io/sc3/plethora/gameplay/manipulator/ManipulatorBlockEntity.kt
+++ b/src/main/java/io/sc3/plethora/gameplay/manipulator/ManipulatorBlockEntity.kt
@@ -140,6 +140,7 @@ class ManipulatorBlockEntity(
   }
 
   override fun onUse(player: PlayerEntity, hand: Hand, hit: BlockHitResult): ActionResult {
+    if (!player.canModifyBlocks()) return ActionResult.PASS
     if (player.entityWorld.isClient) return ActionResult.SUCCESS
     
     val world = world ?: return ActionResult.SUCCESS


### PR DESCRIPTION
Most blocks (with the exceptions of buttons and levers) ignore right clicks when the player is in adventure mode. The manipulator should probably do the same.