### PR TITLE
fix: Don't wrap return value in a table

### DIFF
--- a/src/main/java/io/sc3/plethora/core/executor/BasicExecutor.java
+++ b/src/main/java/io/sc3/plethora/core/executor/BasicExecutor.java
@@ -49,7 +49,6 @@ public final class BasicExecutor implements IResultExecutor {
 	}
 
 	private static class BlockingTask implements LuaTask {
-		Object[] returnValue;
 		private FutureMethodResult.Resolver resolver;
 		private Callable<FutureMethodResult> callback;
 
@@ -66,8 +65,7 @@ public final class BasicExecutor implements IResultExecutor {
 				try {
 					FutureMethodResult result = callback.call();
 					if (result.isFinal()) {
-						returnValue = result.getResult().getResult();
-						return new Object[] { returnValue };
+						return result.getResult().getResult();
 					} else {
 						resolver = result.getResolver();
 						callback = result.getCallback();


### PR DESCRIPTION
`BasicExecutor` would box the return `Object[]` into another `Object[]` causing methods to return a table of `{ ... }` rather than `...`.

This is a breaking change, but only really affects calls to `getMetadata` on item stacks, so I personally I think it's fine - happy to not merge if you disagree though!
