### PR TITLE
fix: fix namespace/description and typos in ArmorItemMeta

### DIFF
--- a/src/main/java/io/sc3/plethora/integration/vanilla/meta/item/ArmorItemMeta.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/meta/item/ArmorItemMeta.kt
@@ -6,9 +6,10 @@ import net.minecraft.item.DyeableArmorItem
 import net.minecraft.item.ItemStack
 
 /**
- * Meta provider for amour properties. Material is handled in [ItemMaterialMeta].
+ * Meta provider for armour properties. Material is handled in [ItemMaterialMeta].
  */
-object ArmorItemMeta : ItemStackMetaProvider<ArmorItem>(ArmorItem::class.java, "Provides type and colour of amour.") {
+object ArmorItemMeta : ItemStackMetaProvider<ArmorItem>(ArmorItem::class.java, "armor",
+  description = "Provides type and colour of armour.") {
   override fun getMeta(stack: ItemStack, item: ArmorItem): Map<String, *> {
     val data = mutableMapOf<String, Any>(
       "armorType" to item.slotType.getName()


### PR DESCRIPTION
<img width="554" alt="image" src="https://github.com/SwitchCraftCC/Plethora-Fabric/assets/24967425/852a109e-e5a9-4514-89b8-321fd2fa9329">

Previously the description was put in the place of the namespace, which meant that it would get added as a key for the metadata table returned. Also, fix typo "amour" -> "armour" 