### PR TITLE
fix: laser angle offsets

### DIFF
--- a/src/main/java/io/sc3/plethora/api/method/ArgumentExt.kt
+++ b/src/main/java/io/sc3/plethora/api/method/ArgumentExt.kt
@@ -84,8 +84,8 @@ object ArgumentExt {
 
   fun IArguments.optHand(index: Int): Hand {
     return when (val hand = optString(index, "main")!!.lowercase()) {
-      "main", "mainhand", "right" -> Hand.MAIN_HAND
-      "off", "offhand", "left" -> Hand.OFF_HAND
+      "main", "mainhand" -> Hand.MAIN_HAND
+      "off", "offhand" -> Hand.OFF_HAND
       else -> throw LuaException("Unknown hand '$hand', expected 'main' or 'off'")
     }
   }

--- a/src/main/java/io/sc3/plethora/gameplay/modules/laser/LaserMethods.kt
+++ b/src/main/java/io/sc3/plethora/gameplay/modules/laser/LaserMethods.kt
@@ -56,12 +56,12 @@ object LaserMethods {
       laser.setShooter(entity, profile)
 
       if (ctx.hasContext(BlockEntity::class.java) || ctx.hasContext(ITurtleAccess::class.java)) {
-          laser.setPosition(pos.add(Vec3d(0.5, 0.5, 0.5)))
-          laser.setPosition(pos.add(Vec3d(
-            MathHelper.clamp(motionX*1.25, -0.75, 0.75),
-            MathHelper.clamp(motionY*1.25, -0.75, 0.75),
-            MathHelper.clamp(motionZ*1.25, -0.75, 0.75)
-          )))
+        laser.setPosition(pos.add(Vec3d(0.5, 0.5, 0.5)))
+        laser.setPosition(pos.add(Vec3d(
+          MathHelper.clamp(motionX * 1.25, -0.75, 0.75),
+          MathHelper.clamp(motionY * 1.25, -0.75, 0.75),
+          MathHelper.clamp(motionZ * 1.25, -0.75, 0.75)
+        )))
       } else if (ctx.hasContext(Entity::class.java)) {
         val entity = ctx.getContext(Entity::class.java)
         val vector = entity.pos

--- a/src/main/java/io/sc3/plethora/gameplay/modules/laser/LaserMethods.kt
+++ b/src/main/java/io/sc3/plethora/gameplay/modules/laser/LaserMethods.kt
@@ -37,7 +37,6 @@ object LaserMethods {
     val yaw = Helpers.normaliseAngle(args.getFiniteDouble(0))
     val pitch = Helpers.normaliseAngle(args.getFiniteDouble(1))
     val potency = args.assertDoubleBetween(2, cfg.minimumPotency, cfg.maximumPotency, "Potency out of range (%s).").toFloat()
-    val old = args.optBoolean(3, false)
 
     val motionX = -sin(yaw / 180.0f * PI.toFloat()) * cos(pitch / 180.0f * PI.toFloat())
     val motionZ =  cos(yaw / 180.0f * PI.toFloat()) * cos(pitch / 180.0f * PI.toFloat())

--- a/src/main/java/io/sc3/plethora/gameplay/modules/laser/LaserMethods.kt
+++ b/src/main/java/io/sc3/plethora/gameplay/modules/laser/LaserMethods.kt
@@ -16,6 +16,7 @@ import io.sc3.plethora.util.Helpers
 import io.sc3.plethora.util.PlayerHelpers
 import net.minecraft.block.entity.BlockEntity
 import net.minecraft.entity.Entity
+import net.minecraft.util.math.MathHelper
 import net.minecraft.util.math.Vec3d
 import java.lang.Math.PI
 import java.util.concurrent.Callable
@@ -36,6 +37,7 @@ object LaserMethods {
     val yaw = Helpers.normaliseAngle(args.getFiniteDouble(0))
     val pitch = Helpers.normaliseAngle(args.getFiniteDouble(1))
     val potency = args.assertDoubleBetween(2, cfg.minimumPotency, cfg.maximumPotency, "Potency out of range (%s).").toFloat()
+    val old = args.optBoolean(3, false)
 
     val motionX = -sin(yaw / 180.0f * PI.toFloat()) * cos(pitch / 180.0f * PI.toFloat())
     val motionZ =  cos(yaw / 180.0f * PI.toFloat()) * cos(pitch / 180.0f * PI.toFloat())
@@ -55,24 +57,12 @@ object LaserMethods {
       laser.setShooter(entity, profile)
 
       if (ctx.hasContext(BlockEntity::class.java) || ctx.hasContext(ITurtleAccess::class.java)) {
-        val vOff = 0.3 // The laser is 0.25 high, so we add a little more.
-
-        // Offset positions to be around the edge of the manipulator. Avoids breaking the manipulator and the
-        // block below/above in most cases.
-        // Also offset to be just above/below the manipulator, depending on the pitch.
-
-        val offset = if (pitch < -60) {
-          Vec3d(0.0, 0.5 + vOff, 0.0)
-        } else if (pitch > 60) {
-          Vec3d(0.0, -0.5 - vOff, 0.0)
-        } else {
-          // The laser is 0.25 wide, the offset from the centre is 0.5.
-          val hOff = 0.9
-          val length = sqrt(motionX * motionX + motionZ * motionZ)
-          Vec3d(motionX / length * hOff, 0.0, motionZ / length * hOff)
-        }
-
-        laser.setPosition(pos.add(offset))
+          laser.setPosition(pos.add(Vec3d(0.5, 0.5, 0.5)))
+          laser.setPosition(pos.add(Vec3d(
+            MathHelper.clamp(motionX*1.25, -0.75, 0.75),
+            MathHelper.clamp(motionY*1.25, -0.75, 0.75),
+            MathHelper.clamp(motionZ*1.25, -0.75, 0.75)
+          )))
       } else if (ctx.hasContext(Entity::class.java)) {
         val entity = ctx.getContext(Entity::class.java)
         val vector = entity.pos


### PR DESCRIPTION
Changes the position from which the laser is fired from block entities by taking the motion of the laser and clamping it to the perimeter of the cube from the center of the block. This could potentially break existing programs that depended on the weird prior behavior.

Program to demonstrate changes, to be run in a turtle with a laser in the left slot, some distance above the ground (for visibility):
```lua
local l = peripheral.wrap("left")
for p = 0, 360, 5 do
  for y = 0, 360, 5 do
    l.fire(y, p, 0.5)
  end
end
```

fixes: #94
