### PR TITLE
fix: remove misleading optional arguments in .use

### DIFF
--- a/src/main/java/io/sc3/plethora/api/method/ArgumentExt.kt
+++ b/src/main/java/io/sc3/plethora/api/method/ArgumentExt.kt
@@ -84,8 +84,8 @@ object ArgumentExt {
 
   fun IArguments.optHand(index: Int): Hand {
     return when (val hand = optString(index, "main")!!.lowercase()) {
-      "main", "mainhand", "right" -> Hand.MAIN_HAND
-      "off", "offhand", "left" -> Hand.OFF_HAND
+      "main", "mainhand" -> Hand.MAIN_HAND
+      "off", "offhand" -> Hand.OFF_HAND
       else -> throw LuaException("Unknown hand '$hand', expected 'main' or 'off'")
     }
   }


### PR DESCRIPTION
Removes "left"/"right" as valid names for the kinetic augment's `.use` method. Prevents the misleading situation where "right" refers to the main hand, which can be configured by the user to be the left hand (making the offhand the right hand).

fixes: #87