### PR TITLE
fix: NI pocket access returning rounded position

### DIFF
--- a/src/main/java/io/sc3/plethora/gameplay/neural/NeuralComputer.kt
+++ b/src/main/java/io/sc3/plethora/gameplay/neural/NeuralComputer.kt
@@ -18,15 +18,20 @@ import net.minecraft.server.world.ServerWorld
 import net.minecraft.util.Identifier
 import net.minecraft.util.collection.DefaultedList
 import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.Vec3d
 import java.lang.ref.WeakReference
 import javax.annotation.Nonnull
 
 class NeuralComputer(
   world: ServerWorld,
-  pos: BlockPos,
+  pos: Vec3d,
   computerId: Int,
   label: String?
-) : ServerComputer(world, pos, properties(computerId, ADVANCED).label(label).terminalSize(WIDTH, HEIGHT)) {
+) : ServerComputer(
+  world,
+  BlockPos(pos.x.toInt(), pos.y.toInt(), pos.z.toInt()),
+  properties(computerId, ADVANCED).label(label).terminalSize(WIDTH, HEIGHT)
+) {
   var entity: WeakReference<LivingEntity>? = null
     private set
 
@@ -38,7 +43,7 @@ class NeuralComputer(
   private var moduleDataDirty = false
 
   val executor = TaskRunner()
-  private val access: NeuralPocketAccess = NeuralPocketAccess(this)
+  private val access: NeuralPocketAccess = NeuralPocketAccess(this, pos)
 
   fun readModuleData(nbt: NbtCompound) {
     for (key in nbt.keys) {
@@ -71,6 +76,7 @@ class NeuralComputer(
     }
 
     setPosition(owner.entityWorld as ServerWorld, owner.blockPos)
+    access.updatePosition(owner.pos)
 
     // Sync changed slots
     if (dirty != 0) {

--- a/src/main/java/io/sc3/plethora/gameplay/neural/NeuralComputerHandler.java
+++ b/src/main/java/io/sc3/plethora/gameplay/neural/NeuralComputerHandler.java
@@ -54,7 +54,7 @@ public class NeuralComputerHandler {
                 : ComputerCraftAPI.createUniqueNumberedSaveDir(owner.getServer(), IDAssigner.COMPUTER);
 
             String label = stack.hasCustomName() ? stack.getName().getString() : null;
-            neural = new NeuralComputer((ServerWorld)owner.getEntityWorld(), owner.getBlockPos(), computerId, label);
+            neural = new NeuralComputer((ServerWorld)owner.getEntityWorld(), owner.getPos(), computerId, label);
             neural.readModuleData(nbt.getCompound(MODULE_DATA));
 
             nbt.putInt(SESSION_ID, sessionId);

--- a/src/main/java/io/sc3/plethora/gameplay/neural/NeuralPocketAccess.java
+++ b/src/main/java/io/sc3/plethora/gameplay/neural/NeuralPocketAccess.java
@@ -22,9 +22,11 @@ import java.util.Map;
 public class NeuralPocketAccess implements IPocketAccess {
     private final NeuralComputer neural;
     private UpgradeData<IPocketUpgrade> upgradeData;
+    private Vec3d position;
 
-    public NeuralPocketAccess(NeuralComputer neural) {
+    public NeuralPocketAccess(NeuralComputer neural, Vec3d position) {
         this.neural = neural;
+        this.position = position;
     }
 
   /**
@@ -44,7 +46,13 @@ public class NeuralPocketAccess implements IPocketAccess {
    */
   @Override
   public Vec3d getPosition() {
-    return this.neural.getPosition().toCenterPos();
+    // This method can be called from off-thread, and so we must use the cached position rather than rereading
+    // from the holder.
+    return this.position;
+  }
+
+  public void updatePosition(Vec3d position) {
+    this.position = position;
   }
 
   @Nullable


### PR DESCRIPTION
This PR resolves #113 by caching the player's Vec3d position instead of using the NI's BlockPos.